### PR TITLE
Typo at line 45

### DIFF
--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -42,7 +42,7 @@ You can use custom ports either via `config.json` file:
 
 ```json
 {
-  "socketURL": "http:s//yourdomain.com:9001/",
+  "socketURL": "https://yourdomain.com:9001/",
   "socketMessageEvent": "RTCMultiConnection-Message"
 }
 ```


### PR DESCRIPTION
Typo

    "socketURL": "http:s//yourdomain.com:9001/",

to

    "socketURL": "https://yourdomain.com:9001/",