### PR TITLE
Add support for ES6 imports (module resolution)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "url": "http://www.muazkhan.com/"
   },
   "description": "RTCMultiConnection is a WebRTC JavaScript wrapper library runs top over RTCPeerConnection API to support all possible peer-to-peer features.",
-  "main": "server.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/muaz-khan/RTCMultiConnection.git"
@@ -19,7 +18,7 @@
   "engines": {
     "node": "latest"
   },
-  "main": "RTCMultiConnection.js",
+  "main": "./dist/RTCMultiConnection.js",
   "keywords": [
     "peer-to-peer",
     "peer2peer",


### PR DESCRIPTION
My React app was having trouble resolving for this module. It turns out the problem was that the `main` entry in the `package.json` did not point to the actual file that my app needed.

By simply changing `{ main: "RTCMultiConnection.js" }` to `{ main: "./dist/RTCMultiConnection.js" }`, I can now do:

```js
import "rtcmulticonnection-v3";
```

And it will put `RTCMultiConnection` as a global variable. In order to do something even more idomatic (by modern Javascript standards):

```js
import RTCMultiConnection from "rtcmulticonnection-v3";
```

That will require compiling the output as a CommonJS module. I did not have time to do this, it's a bit more work than what I've done here, but it's something to think about going forward. Nevertheless, this PR should make it possible to use this library in modern apps.