### PR TITLE
Removed dist/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ rmc-debug.log
 _site
 Gemfile.lock
 *.pyc
-dist/
 .vscode/
 v2.2.2
 node_modules


### PR DESCRIPTION
According to the [installation guide](https://github.com/muaz-khan/RTCMultiConnection/blob/master/docs/installation-guide.md), when we deploy, the dist/ folder is ignored which contains the RTCMultiConnection.min.js file which is required by the web app trying to connect to the socket.