### PR TITLE
fix: add compatibility socketIO v3 on socket connect

### DIFF
--- a/admin/admin-ui.js
+++ b/admin/admin-ui.js
@@ -30,7 +30,7 @@ setTimeout(function() {
 }, 500);
 
 function connectSocket(username, password) {
-    socket = io.connect('/?userid=admin&adminUserName=' + username + '&adminPassword=' + password);
+    socket = io.connect('/', {query:"userid=admin&adminUserName=" + username + "&adminPassword=" + password});
     socket.on('admin', function(message) {
         if(message.error) {
             alertBox(message.error, 'Invalid Credentials', null, function() {


### PR DESCRIPTION
On my recent install, when we try to start the admin on remote, the legacy code to connect  the admin client is broken because the socket io version used now is v3 instaed v2.2 (on the current demo online).

In this case, the client try to connect the socket server vis /admin/socket.io because the syntax `/?userid=admin&adminUs...` make a bad interpretation af the host.

before few hours to find the issue, i have fixed that when the correct syntax to use the connect function from socket io client as you can see in this topic  : https://stackoverflow.com/questions/25083564/socket-io-parameters-on-connection

Enjoy  ;)


 