### PR TITLE
Also accept messages for sessionid

### DIFF
--- a/dev/SSEConnection.js
+++ b/dev/SSEConnection.js
@@ -104,7 +104,7 @@ function SSEConnection(connection, connectCallback) {
     var mPeer = connection.multiPeersHandler;
 
     function onMessagesCallback(message) {
-        if (message.remoteUserId != connection.userid) return;
+        if (message.remoteUserId != connection.userid && message.remoteUserId != conneciton.sessionid) return;
 
         if (connection.peers[message.sender] && connection.peers[message.sender].extra != message.message.extra) {
             connection.peers[message.sender].extra = message.message.extra;


### PR DESCRIPTION
The sessionid is used as a remoteUserId for events like 'join-room'.

This allows the client to respond to that, initiating the negotiation.